### PR TITLE
feat(widget): add widget header, footer and view components

### DIFF
--- a/apps/widget/app/page.tsx
+++ b/apps/widget/app/page.tsx
@@ -1,28 +1,16 @@
 "use client";
 
-import { useVapi } from "@/modules/widget/hooks/use-vapi";
-import { Button } from "@workspace/ui/components/button";
+import { WidgetView } from "@/modules/widget/ui/views/widget-view";
+import { use } from "react";
 
-export default function Page() {
-  const {
-    isSpeaking,
-    isConnected,
-    isConnecting,
-    transcript,
-    startCall,
-    endCall,
-  } = useVapi();
+interface Props {
+  searchParams: Promise<{
+    organizationId: string;
+  }>;
+}
 
-  return (
-    <div className="flex flex-col items-center justify-center min-h-svh max-w-md mx-auto w-full">
-      <Button onClick={() => startCall()}>Start Call</Button>
-      <Button onClick={() => endCall()} variant="destructive">
-        End Call
-      </Button>
-      <p>isConnected: {`${isConnected}`}</p>
-      <p>isConnecting: {`${isConnecting}`}</p>
-      <p>isSpeaking: {`${isSpeaking}`}</p>
-      <p>{JSON.stringify(transcript, null, 2)}</p>
-    </div>
-  );
+export default function Page({ searchParams }: Props) {
+  const { organizationId } = use(searchParams);
+
+  return <WidgetView organizationId={organizationId} />;
 }

--- a/apps/widget/modules/widget/ui/components/widget-footer.tsx
+++ b/apps/widget/modules/widget/ui/components/widget-footer.tsx
@@ -1,0 +1,33 @@
+import { Button } from "@workspace/ui/components/button";
+import { cn } from "@workspace/ui/lib/utils";
+import { Home, Inbox } from "lucide-react";
+import React from "react";
+
+const WidgetFooter = () => {
+  const screen = "selection";
+
+  return (
+    <footer className="flex items-center justify-between border-t bg-background">
+      <Button
+        className="h-14 flex-1 rounded-none"
+        onClick={() => {}}
+        size="icon"
+        variant="ghost"
+      >
+        <Home
+          className={cn("size-5", screen === "selection" && "text-primary")}
+        />
+      </Button>
+      <Button
+        className="h-14 flex-1 rounded-none"
+        onClick={() => {}}
+        size="icon"
+        variant="ghost"
+      >
+        <Inbox className={cn("size-5", screen === "inbox" && "text-primary")} />
+      </Button>
+    </footer>
+  );
+};
+
+export default WidgetFooter;

--- a/apps/widget/modules/widget/ui/components/widget-header.tsx
+++ b/apps/widget/modules/widget/ui/components/widget-header.tsx
@@ -1,0 +1,23 @@
+import { cn } from "@workspace/ui/lib/utils";
+import React, { ReactNode } from "react";
+
+const WidgetHeader = ({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) => {
+  return (
+    <header
+      className={cn(
+        "bg-gradient-to-b from-primary to-[#0b63f6] p-4 text-primary-foreground",
+        className
+      )}
+    >
+      {children}
+    </header>
+  );
+};
+
+export default WidgetHeader;

--- a/apps/widget/modules/widget/ui/views/widget-view.tsx
+++ b/apps/widget/modules/widget/ui/views/widget-view.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import WidgetFooter from "@/modules/widget/ui/components/widget-footer";
+import WidgetHeader from "@/modules/widget/ui/components/widget-header";
+
+interface Props {
+  organizationId: string;
+}
+
+export const WidgetView = ({ organizationId }: Props) => {
+  return (
+    //TODO: Confirm whether or not min-h-screen and min-w-screen is needed
+    <div className="min-h-screen min-w-screen flex h-full w-full flex-col overflow-hidden rounded-xl border bg-muted">
+      <WidgetHeader>
+        <div className="flex flex-col justify-between gap-y-2 px-2 py-6 font-semibold">
+          <p className="text-3xl">Hi There! 👋</p>
+          <p className="text-lg">How can we help you today?</p>
+        </div>
+      </WidgetHeader>
+      <div className="flex flex-1">Widget View - {organizationId}</div>
+      <WidgetFooter />
+    </div>
+  );
+};


### PR DESCRIPTION
Implement new widget UI components including header with gradient background, footer with navigation buttons, and main view container. Replace previous page implementation with the new widget view that accepts organizationId as prop.