### PR TITLE
feat(widget): add state management with jotai for widget screens

### DIFF
--- a/apps/widget/components/providers.tsx
+++ b/apps/widget/components/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { Provider } from "jotai";
 import { ConvexProvider, ConvexReactClient } from "convex/react";
 
 const convex = new ConvexReactClient(
@@ -13,5 +14,9 @@ const convex = new ConvexReactClient(
 );
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  return <ConvexProvider client={convex}>{children}</ConvexProvider>;
+  return (
+    <ConvexProvider client={convex}>
+      <Provider>{children}</Provider>
+    </ConvexProvider>
+  );
 }

--- a/apps/widget/modules/widget/atoms/widget-atoms.ts
+++ b/apps/widget/modules/widget/atoms/widget-atoms.ts
@@ -1,0 +1,5 @@
+import { atom } from "jotai";
+import { WidgetScreen } from "@/modules/widget/types";
+
+//* Basic widget state atoms
+export const screenAtom = atom<WidgetScreen>("auth");

--- a/apps/widget/modules/widget/constants.ts
+++ b/apps/widget/modules/widget/constants.ts
@@ -1,0 +1,12 @@
+export const WIDGET_SCREENS = [
+  "error",
+  "loading",
+  "selection",
+  "voice",
+  "auth",
+  "inbox",
+  "chat",
+  "contact",
+] as const;
+
+export const CONTACT_SESSION_KEY = "echo_contact_session";

--- a/apps/widget/modules/widget/types.ts
+++ b/apps/widget/modules/widget/types.ts
@@ -1,0 +1,3 @@
+import { WIDGET_SCREENS } from "@/modules/widget/constants";
+
+export type WidgetScreen = (typeof WIDGET_SCREENS)[number];

--- a/apps/widget/modules/widget/ui/views/widget-view.tsx
+++ b/apps/widget/modules/widget/ui/views/widget-view.tsx
@@ -1,19 +1,31 @@
 "use client";
 
-import WidgetFooter from "@/modules/widget/ui/components/widget-footer";
-import WidgetHeader from "@/modules/widget/ui/components/widget-header";
 import { WidgetAuthScreen } from "@/modules/widget/ui/screens/widget-auth-screen";
+import { useAtomValue } from "jotai";
+import { screenAtom } from "@/modules/widget/atoms/widget-atoms";
 
 interface Props {
   organizationId: string;
 }
 
 export const WidgetView = ({ organizationId }: Props) => {
+  const screen = useAtomValue(screenAtom);
+
+  const screenComponents = {
+    error: <p>TODO: Error</p>,
+    loading: <p>TODO: Loading</p>,
+    auth: <WidgetAuthScreen />,
+    voice: <p>TODO: Voice</p>,
+    inbox: <p>TODO: Inbox</p>,
+    selection: <p>TODO: Selection</p>,
+    chat: <p>TODO: Chat</p>,
+    contact: <p>TODO: Contact</p>,
+  };
+
   return (
     //TODO: Confirm whether or not min-h-screen and min-w-screen is needed
     <div className="min-h-screen min-w-screen flex h-full w-full flex-col overflow-hidden rounded-xl border bg-muted">
-      <WidgetAuthScreen />
-      {/* <WidgetFooter /> */}
+      {screenComponents[screen]}
     </div>
   );
 };

--- a/apps/widget/package.json
+++ b/apps/widget/package.json
@@ -18,6 +18,7 @@
     "@workspace/math": "workspace:*",
     "@workspace/ui": "workspace:*",
     "convex": "^1.25.4",
+    "jotai": "^2.13.1",
     "lucide-react": "^0.475.0",
     "next": "^15.2.3",
     "next-themes": "^0.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,9 @@ importers:
       convex:
         specifier: ^1.25.4
         version: 1.25.4(@clerk/clerk-react@5.38.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      jotai:
+        specifier: ^2.13.1
+        version: 2.13.1(@babel/core@7.28.0)(@babel/template@7.27.2)(@types/react@19.0.10)(react@19.0.0)
       lucide-react:
         specifier: ^0.475.0
         version: 0.475.0(react@19.0.0)
@@ -3566,6 +3569,24 @@ packages:
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
+
+  jotai@2.13.1:
+    resolution: {integrity: sha512-cRsw6kFeGC9Z/D3egVKrTXRweycZ4z/k7i2MrfCzPYsL9SIWcPXTyqv258/+Ay8VUEcihNiE/coBLE6Kic6b8A==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@babel/core': '>=7.0.0'
+      '@babel/template': '>=7.0.0'
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@babel/template':
+        optional: true
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
@@ -8216,6 +8237,13 @@ snapshots:
       supports-color: 8.1.1
 
   jiti@2.4.2: {}
+
+  jotai@2.13.1(@babel/core@7.28.0)(@babel/template@7.27.2)(@types/react@19.0.10)(react@19.0.0):
+    optionalDependencies:
+      '@babel/core': 7.28.0
+      '@babel/template': 7.27.2
+      '@types/react': 19.0.10
+      react: 19.0.0
 
   js-cookie@3.0.5: {}
 


### PR DESCRIPTION
- Add jotai dependency for state management
- Create widget screen types and constants
- Implement screen atom and integrate with widget view
- Update providers to include jotai Provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Widget now renders screens dynamically based on app state.
  - Introduced standardized screen options and constants for consistent navigation.

- Refactor
  - Updated application providers to include a global state context.
  - Reworked the widget view to use a centralized screen mapping.

- Chores
  - Added a new dependency to support state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->