### PR TITLE
feat(widget): add conversation support with chat and selection screens

### DIFF
--- a/apps/widget/modules/widget/atoms/widget-atoms.ts
+++ b/apps/widget/modules/widget/atoms/widget-atoms.ts
@@ -19,3 +19,4 @@ export const contactSessionIdAtomFamily = atomFamily((organizationId: string) =>
 
 export const errorMessageAtom = atom<string | null>(null);
 export const loadingMessageAtom = atom<string | null>(null);
+export const conversationIdAtom = atom<Id<"conversations"> | null>(null);

--- a/apps/widget/modules/widget/ui/screens/widget-chat-screen.tsx
+++ b/apps/widget/modules/widget/ui/screens/widget-chat-screen.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Button } from "@workspace/ui/components/button";
+import WidgetHeader from "@/modules/widget/ui/components/widget-header";
+import { ArrowLeft, Menu } from "lucide-react";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  contactSessionIdAtomFamily,
+  conversationIdAtom,
+  organizationIdAtom,
+  screenAtom,
+} from "@/modules/widget/atoms/widget-atoms";
+import { useQuery } from "convex/react";
+import { api } from "@workspace/backend/_generated/api";
+
+export const WidgetChatScreen = () => {
+  const setScreen = useSetAtom(screenAtom);
+  const setConversationId = useSetAtom(conversationIdAtom);
+
+  const conversationId = useAtomValue(conversationIdAtom);
+  const organizationId = useAtomValue(organizationIdAtom);
+  const contactSessionId = useAtomValue(
+    contactSessionIdAtomFamily(organizationId || "")
+  );
+
+  const conversation = useQuery(
+    api.public.conversations.getOne,
+    conversationId && contactSessionId
+      ? {
+          conversationId,
+          contactSessionId,
+        }
+      : "skip"
+  );
+
+  const onBack = () => {
+    setConversationId(null);
+    setScreen("selection");
+  };
+
+  return (
+    <>
+      <WidgetHeader className="flex items-center justify-between">
+        <div className="flex items-center gap-x-2">
+          <Button size="icon" variant="transparent" onClick={onBack}>
+            <ArrowLeft />
+          </Button>
+          <p>Chat</p>
+        </div>
+        <Button size="icon" variant="transparent">
+          <Menu />
+        </Button>
+      </WidgetHeader>
+      <div className="flex flex-1 flex-col gap-y-4 p-4">
+        {JSON.stringify(conversation, null, 2)}
+      </div>
+    </>
+  );
+};

--- a/apps/widget/modules/widget/ui/screens/widget-selection-screen.tsx
+++ b/apps/widget/modules/widget/ui/screens/widget-selection-screen.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Button } from "@workspace/ui/components/button";
+import WidgetHeader from "@/modules/widget/ui/components/widget-header";
+import { ChevronRight, MessageSquareText } from "lucide-react";
+import { useAtomValue, useSetAtom } from "jotai";
+import {
+  contactSessionIdAtomFamily,
+  conversationIdAtom,
+  errorMessageAtom,
+  organizationIdAtom,
+  screenAtom,
+} from "@/modules/widget/atoms/widget-atoms";
+import { useMutation } from "convex/react";
+import { api } from "@workspace/backend/_generated/api";
+import { useState } from "react";
+
+export const WidgetSelectionScreen = () => {
+  const setScreen = useSetAtom(screenAtom);
+  const setErrorMessage = useSetAtom(errorMessageAtom);
+  const setConversationId = useSetAtom(conversationIdAtom);
+
+  const organizationId = useAtomValue(organizationIdAtom);
+  const contactSessionId = useAtomValue(
+    contactSessionIdAtomFamily(organizationId || "")
+  );
+
+  const createConversation = useMutation(api.public.conversations.create);
+  const [isPending, setIsPending] = useState(false);
+
+  const handleNewConversation = async () => {
+    if (!organizationId) {
+      setScreen("error");
+      setErrorMessage("Missing Organization ID");
+      return;
+    }
+
+    if (!contactSessionId) {
+      setScreen("auth");
+      return;
+    }
+
+    setIsPending(true);
+    try {
+      const conversationId = await createConversation({
+        contactSessionId,
+        organizationId,
+      });
+      setConversationId(conversationId);
+      setScreen("chat");
+    } catch {
+      setScreen("auth");
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <>
+      <WidgetHeader>
+        <div className="flex flex-col justify-between gap-y-2 px-2 py-6 font-semibold">
+          <p className="text-3xl">Hi there! 👋</p>
+          <p className="text-lg">Let&apos;s get you started</p>
+        </div>
+      </WidgetHeader>
+      <div className="flex flex-1 flex-col gap-y-4 p-4 overflow-y-auto">
+        <Button
+          className="h-16 w-full justify-between"
+          variant="outline"
+          onClick={handleNewConversation}
+          disabled={isPending}
+        >
+          <div className="flex items-center gap-x-2">
+            <MessageSquareText className="size-4" />
+            <span>Start chat</span>
+          </div>
+          <ChevronRight className="size-4" />
+        </Button>
+      </div>
+    </>
+  );
+};

--- a/apps/widget/modules/widget/ui/views/widget-view.tsx
+++ b/apps/widget/modules/widget/ui/views/widget-view.tsx
@@ -5,6 +5,8 @@ import { useAtomValue } from "jotai";
 import { screenAtom } from "@/modules/widget/atoms/widget-atoms";
 import { WidgetErrorScreen } from "@/modules/widget/ui/screens/widget-error-screen";
 import { WidgetLoadingScreen } from "@/modules/widget/ui/screens/widget-loading-screen";
+import { WidgetSelectionScreen } from "@/modules/widget/ui/screens/widget-selection-screen";
+import { WidgetChatScreen } from "@/modules/widget/ui/screens/widget-chat-screen";
 
 interface Props {
   organizationId: string | null;
@@ -19,8 +21,8 @@ export const WidgetView = ({ organizationId }: Props) => {
     auth: <WidgetAuthScreen />,
     voice: <p>TODO: Voice</p>,
     inbox: <p>TODO: Inbox</p>,
-    selection: <p>TODO: Selection</p>,
-    chat: <p>TODO: Chat</p>,
+    selection: <WidgetSelectionScreen />,
+    chat: <WidgetChatScreen />,
     contact: <p>TODO: Contact</p>,
   };
 

--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type {
   FunctionReference,
 } from "convex/server";
 import type * as public_contactSessions from "../public/contactSessions.js";
+import type * as public_conversations from "../public/conversations.js";
 import type * as public_organizations from "../public/organizations.js";
 import type * as users from "../users.js";
 
@@ -27,6 +28,7 @@ import type * as users from "../users.js";
  */
 declare const fullApi: ApiFromModules<{
   "public/contactSessions": typeof public_contactSessions;
+  "public/conversations": typeof public_conversations;
   "public/organizations": typeof public_organizations;
   users: typeof users;
 }>;

--- a/packages/backend/convex/public/conversations.ts
+++ b/packages/backend/convex/public/conversations.ts
@@ -1,0 +1,57 @@
+import { ConvexError, v } from "convex/values";
+import { mutation, query } from "../_generated/server";
+
+export const getOne = query({
+  args: {
+    conversationId: v.id("conversations"),
+    contactSessionId: v.id("contactSessions"),
+  },
+  handler: async (ctx, args) => {
+    const session = await ctx.db.get(args.contactSessionId);
+
+    if (!session || session.expiresAt < Date.now()) {
+      throw new ConvexError({
+        code: "UNAUTHORIZED",
+        message: "Invalid session",
+      });
+    }
+
+    const conversation = await ctx.db.get(args.conversationId);
+    if (!conversation) return null;
+
+    return {
+      _id: conversation._id,
+      status: conversation.status,
+      threadId: conversation.threadId,
+    };
+  },
+});
+
+export const create = mutation({
+  args: {
+    organizationId: v.string(),
+    contactSessionId: v.id("contactSessions"),
+  },
+  handler: async (ctx, args) => {
+    const session = await ctx.db.get(args.contactSessionId);
+
+    if (!session || session.expiresAt < Date.now()) {
+      throw new ConvexError({
+        code: "UNAUTHORIZED",
+        message: "Invalid session",
+      });
+    }
+
+    // TODO: Replace once functionality for thread creation is present
+    const threadId = "12345";
+
+    const conversationId = await ctx.db.insert("conversations", {
+      contactSessionId: session._id,
+      status: "unresolved",
+      organizationId: args.organizationId,
+      threadId,
+    });
+
+    return conversationId;
+  },
+});

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -2,6 +2,20 @@ import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
 export default defineSchema({
+  conversations: defineTable({
+    threadId: v.string(),
+    organizationId: v.string(),
+    contactSessionId: v.id("contactSessions"),
+    status: v.union(
+      v.literal("unresolved"),
+      v.literal("escalated"),
+      v.literal("resolved")
+    ),
+  })
+    .index("by_organization_id", ["organizationId"])
+    .index("by_contact_session_id", ["contactSessionId"])
+    .index("by_thread_id", ["threadId"])
+    .index("by_status_and_organization_id", ["status", "organizationId"]),
   contactSessions: defineTable({
     name: v.string(),
     email: v.string(),

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@workspace/ui/lib/utils"
+import { cn } from "@workspace/ui/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -20,6 +20,8 @@ const buttonVariants = cva(
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
+        transparent:
+          "bg-transparent text-primary-foreground hover:bg-transparent hover:text-primary-foreground/80",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
@@ -33,7 +35,7 @@ const buttonVariants = cva(
       size: "default",
     },
   }
-)
+);
 
 function Button({
   className,
@@ -43,9 +45,9 @@ function Button({
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot : "button"
+  const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
@@ -53,7 +55,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };


### PR DESCRIPTION
- Implement conversation schema and API endpoints
- Add chat and selection screens to widget UI
- Create conversation atoms and integrate with existing auth flow
- Add transparent button variant for UI components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Start a new chat from the selection screen with proper session handling and error states.
  - View an existing conversation in the chat screen and navigate back to selection.
  - Conversation state is stored during the session for seamless transitions.

- UI
  - Introduced a transparent button style for icon-only header actions.
  - Chat screen currently displays conversation details for visibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->