### PR TITLE
feat(widget): add inbox screen with conversation list and navigation

### DIFF
--- a/apps/widget/modules/widget/ui/components/widget-footer.tsx
+++ b/apps/widget/modules/widget/ui/components/widget-footer.tsx
@@ -1,16 +1,19 @@
 import { Button } from "@workspace/ui/components/button";
 import { cn } from "@workspace/ui/lib/utils";
+import { useAtomValue, useSetAtom } from "jotai";
 import { Home, Inbox } from "lucide-react";
 import React from "react";
+import { screenAtom } from "@/modules/widget/atoms/widget-atoms";
 
 const WidgetFooter = () => {
-  const screen = "selection";
+  const screen = useAtomValue(screenAtom);
+  const setScreen = useSetAtom(screenAtom);
 
   return (
     <footer className="flex items-center justify-between border-t bg-background">
       <Button
         className="h-14 flex-1 rounded-none"
-        onClick={() => {}}
+        onClick={() => setScreen("selection")}
         size="icon"
         variant="ghost"
       >
@@ -20,11 +23,11 @@ const WidgetFooter = () => {
       </Button>
       <Button
         className="h-14 flex-1 rounded-none"
-        onClick={() => {}}
+        onClick={() => setScreen("inbox")}
         size="icon"
         variant="ghost"
       >
-        <Inbox className={cn("size-5")} />
+        <Inbox className={cn("size-5", screen === "inbox" && "text-primary")} />
       </Button>
     </footer>
   );

--- a/apps/widget/modules/widget/ui/screens/widget-inbox-screen.tsx
+++ b/apps/widget/modules/widget/ui/screens/widget-inbox-screen.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useAtomValue, useSetAtom } from "jotai";
+import WidgetHeader from "@/modules/widget/ui/components/widget-header";
+import WidgetFooter from "@/modules/widget/ui/components/widget-footer";
+import { Button } from "@workspace/ui/components/button";
+import { ConversationStatusIcon } from "@workspace/ui/components/conversation-status-icon";
+import { ArrowLeft } from "lucide-react";
+import {
+  contactSessionIdAtomFamily,
+  conversationIdAtom,
+  organizationIdAtom,
+  screenAtom,
+} from "@/modules/widget/atoms/widget-atoms";
+import { usePaginatedQuery } from "convex/react";
+import { api } from "@workspace/backend/_generated/api";
+import { formatDistanceToNow } from "date-fns";
+import { useInfiniteScroll } from "@workspace/ui/hooks/use-infinte-scroll";
+import { InfiniteScrollTrigger } from "@workspace/ui/components/infinite-scroll-trigger";
+
+export const WidgetInboxScreen = () => {
+  const setScreen = useSetAtom(screenAtom);
+  const setConversationId = useSetAtom(conversationIdAtom);
+
+  const organizationId = useAtomValue(organizationIdAtom);
+  const contactSessionId = useAtomValue(
+    contactSessionIdAtomFamily(organizationId || "")
+  );
+
+  const conversations = usePaginatedQuery(
+    api.public.conversations.getMany,
+    contactSessionId
+      ? {
+          contactSessionId,
+        }
+      : "skip",
+    {
+      initialNumItems: 10,
+    }
+  );
+
+  const { topElementRef, handleLoadMore, isLoadingMore, canLoadMore } =
+    useInfiniteScroll({
+      status: conversations.status,
+      loadMore: conversations.loadMore,
+      loadSize: 10,
+    });
+
+  return (
+    <>
+      <WidgetHeader>
+        <div className="flex items-center gap-x-2">
+          <Button
+            variant="transparent"
+            size="icon"
+            onClick={() => setScreen("selection")}
+          >
+            <ArrowLeft />
+          </Button>
+          <p>Inbox</p>
+        </div>
+      </WidgetHeader>
+      <div className="flex flex-1 flex-col gap-y-2 p-4 overflow-y-auto">
+        {conversations?.results.length > 0 &&
+          conversations?.results.map((conversation) => (
+            <Button
+              key={conversation._id}
+              className="h-20 w-full justify-between"
+              onClick={() => {
+                setConversationId(conversation._id);
+                setScreen("chat");
+              }}
+              variant="outline"
+            >
+              <div className="flex w-full flex-col gap-4 overflow-hidden text-start">
+                <div className="flex w-full items-center justify-between gap-x-2">
+                  <p className="text-muted-foreground text-xs">Chat</p>
+                  <p className="text-muted-foreground text-xs">
+                    {formatDistanceToNow(new Date(conversation._creationTime))}
+                  </p>
+                </div>
+                <div className="flex w-full items-center justify-between gap-x-2">
+                  <p className="truncate text-sm">
+                    {conversation?.lastMessage?.text}
+                  </p>
+                  <ConversationStatusIcon status={conversation.status} />
+                </div>
+              </div>
+            </Button>
+          ))}
+        <InfiniteScrollTrigger
+          ref={topElementRef}
+          isLoadingMore={isLoadingMore}
+          canLoadMore={canLoadMore}
+          onLoadMore={handleLoadMore}
+        />
+      </div>
+      <WidgetFooter />
+    </>
+  );
+};

--- a/apps/widget/modules/widget/ui/screens/widget-selection-screen.tsx
+++ b/apps/widget/modules/widget/ui/screens/widget-selection-screen.tsx
@@ -14,6 +14,7 @@ import {
 import { useMutation } from "convex/react";
 import { api } from "@workspace/backend/_generated/api";
 import { useState } from "react";
+import WidgetFooter from "@/modules/widget/ui/components/widget-footer";
 
 export const WidgetSelectionScreen = () => {
   const setScreen = useSetAtom(screenAtom);
@@ -77,6 +78,7 @@ export const WidgetSelectionScreen = () => {
           <ChevronRight className="size-4" />
         </Button>
       </div>
+      <WidgetFooter />
     </>
   );
 };

--- a/apps/widget/modules/widget/ui/views/widget-view.tsx
+++ b/apps/widget/modules/widget/ui/views/widget-view.tsx
@@ -7,6 +7,7 @@ import { WidgetErrorScreen } from "@/modules/widget/ui/screens/widget-error-scre
 import { WidgetLoadingScreen } from "@/modules/widget/ui/screens/widget-loading-screen";
 import { WidgetSelectionScreen } from "@/modules/widget/ui/screens/widget-selection-screen";
 import { WidgetChatScreen } from "@/modules/widget/ui/screens/widget-chat-screen";
+import { WidgetInboxScreen } from "../screens/widget-inbox-screen";
 
 interface Props {
   organizationId: string | null;
@@ -20,7 +21,7 @@ export const WidgetView = ({ organizationId }: Props) => {
     loading: <WidgetLoadingScreen organizationId={organizationId} />,
     auth: <WidgetAuthScreen />,
     voice: <p>TODO: Voice</p>,
-    inbox: <p>TODO: Inbox</p>,
+    inbox: <WidgetInboxScreen />,
     selection: <WidgetSelectionScreen />,
     chat: <WidgetChatScreen />,
     contact: <p>TODO: Contact</p>,

--- a/apps/widget/package.json
+++ b/apps/widget/package.json
@@ -19,6 +19,7 @@
     "@workspace/math": "workspace:*",
     "@workspace/ui": "workspace:*",
     "convex": "^1.25.4",
+    "date-fns": "^4.1.0",
     "jotai": "^2.13.1",
     "lucide-react": "^0.475.0",
     "next": "^15.2.3",

--- a/packages/backend/convex/public/conversations.ts
+++ b/packages/backend/convex/public/conversations.ts
@@ -1,8 +1,63 @@
 import { ConvexError, v } from "convex/values";
 import { mutation, query } from "../_generated/server";
 import { supportAgent } from "../system/ai/agents/supportAgent";
-import { saveMessage } from "@convex-dev/agent";
+import { MessageDoc, saveMessage } from "@convex-dev/agent";
 import { components } from "../_generated/api";
+import { paginationOptsValidator } from "convex/server";
+
+export const getMany = query({
+  args: {
+    contactSessionId: v.id("contactSessions"),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    const contactSession = await ctx.db.get(args.contactSessionId);
+
+    if (!contactSession || contactSession.expiresAt < Date.now()) {
+      throw new ConvexError({
+        code: "UNAUTHORIZED",
+        message: "Invalid session",
+      });
+    }
+
+    const conversations = await ctx.db
+      .query("conversations")
+      .withIndex("by_contact_session_id", (q) =>
+        q.eq("contactSessionId", args.contactSessionId)
+      )
+      .order("desc")
+      .paginate(args.paginationOpts);
+
+    const conversationsWithLastMessage = await Promise.all(
+      conversations.page.map(async (conversation) => {
+        let lastMessage: MessageDoc | null = null;
+
+        const messages = await supportAgent.listMessages(ctx, {
+          threadId: conversation.threadId,
+          paginationOpts: { numItems: 1, cursor: null },
+        });
+
+        if (messages.page.length > 0) {
+          lastMessage = messages.page[0] ?? null;
+        }
+
+        return {
+          _id: conversation._id,
+          _creationTime: conversation._creationTime,
+          status: conversation.status,
+          organizationId: conversation.organizationId,
+          threadId: conversation.threadId,
+          lastMessage,
+        };
+      })
+    );
+
+    return {
+      ...conversations,
+      page: conversationsWithLastMessage,
+    };
+  },
+});
 
 export const getOne = query({
   args: {

--- a/packages/ui/src/components/conversation-status-icon.tsx
+++ b/packages/ui/src/components/conversation-status-icon.tsx
@@ -1,0 +1,39 @@
+import { ArrowRight, ArrowUp, CheckIcon } from "lucide-react";
+import { cn } from "@workspace/ui/lib/utils.js";
+
+interface ConversationStatusIconProps {
+  status: "unresolved" | "escalated" | "resolved";
+}
+
+const statusConfig = {
+  resolved: {
+    icon: CheckIcon,
+    bgColor: "bg-[#3FB62F]",
+  },
+  unresolved: {
+    icon: ArrowRight,
+    bgColor: "bg-destructive",
+  },
+  escalated: {
+    icon: ArrowUp,
+    bgColor: "bg-yellow-500",
+  },
+} as const;
+
+export const ConversationStatusIcon = ({
+  status,
+}: ConversationStatusIconProps) => {
+  const config = statusConfig[status];
+  const Icon = config.icon;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center rounded-full p-2",
+        config.bgColor
+      )}
+    >
+      <Icon className="size-3 stroke-3 text-white" />
+    </div>
+  );
+};

--- a/packages/ui/src/components/dicebear-avatar.tsx
+++ b/packages/ui/src/components/dicebear-avatar.tsx
@@ -32,7 +32,7 @@ export const DicebearAvatar = ({
     });
 
     return avatar.toDataUri();
-  }, [seed, size]);
+  }, [seed, size, imageUrl]);
 
   const badgeSize = Math.round(size * 0.5);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       convex:
         specifier: ^1.25.4
         version: 1.25.4(@clerk/clerk-react@5.38.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       jotai:
         specifier: ^2.13.1
         version: 2.13.1(@babel/core@7.28.0)(@babel/template@7.27.2)(@types/react@19.0.10)(react@19.0.0)


### PR DESCRIPTION
- Implement widget inbox screen with paginated conversation list
- Add conversation status icons and last message preview
- Enable navigation between screens using footer buttons
- Add date-fns dependency for date formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an Inbox screen listing conversations with last message preview, relative timestamps, status indicators, and infinite scrolling.
  - Added footer navigation with active state to switch between Home and Inbox.
  - Enabled selecting a conversation to open chat and a back action from Inbox to Home.

- Bug Fixes
  - Avatars now update correctly when a custom image URL changes.

- Chores
  - Updated dependencies to include a date/time utility library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->